### PR TITLE
Run the required checks on every pull request

### DIFF
--- a/.github/workflows/audit-examples.yml
+++ b/.github/workflows/audit-examples.yml
@@ -12,14 +12,11 @@
 
 name: Audit examples
 
+# Runs on every pull request, not just ones that touch examples, because it
+# is a required check on main. When nothing relevant changed it finishes in
+# seconds with "No example folders changed".
 on:
   pull_request:
-    paths:
-      - "examples/**"
-      - "catalog/**"
-      - "scripts/**"
-      - ".arcane-auditor/**"
-      - ".github/workflows/audit-examples.yml"
   workflow_dispatch:
     inputs:
       dirs:

--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -1,13 +1,9 @@
 name: Validate examples
 
+# Runs on every pull request because it is a required check on main. It
+# takes a few seconds, so there is no reason to skip it.
 on:
   pull_request:
-    paths:
-      - "catalog/**"
-      - "examples/**"
-      - "scripts/**"
-      - "hub.config.json"
-      - "README.md"
 
 jobs:
   validate:


### PR DESCRIPTION
## What this PR adds or changes

Removes the `paths:` filters from `Audit examples` and `Validate examples`. Both are required checks on `main`, but the filters skipped them on pull requests that touched only docs (see #10), which left those PRs blocked with no checks reported. Both workflows finish in seconds when nothing relevant changed, so they now run on every pull request.

## Anything reviewers should know?

This PR itself will show only the audit check, because the validate workflow on `main` still has its filter until this merges. Merge with the administrator override, then close and reopen #10 so both checks run there.